### PR TITLE
add accessToken checking to refresh actions

### DIFF
--- a/src/store/authentication/tokens.js
+++ b/src/store/authentication/tokens.js
@@ -4,11 +4,17 @@ const jwtDecode = require('jwt-decode')
 
 const state = () => ({
   sessionLoaded: false,
-  refreshToken: null,
   accessToken: null
 })
 
 const getters = {
+  accessTokenExpiresAt: (state) => {
+    if (state.accessToken) {
+      return jwtDecode(state.accessToken).exp
+    } else {
+      return null
+    }
+  },
   currentSession: (state) => {
     if (state.accessToken) {
       return jwtDecode(state.accessToken).data
@@ -27,13 +33,13 @@ const getters = {
 
 const actions = {
   async init ({ state, commit, dispatch }) {
-    await dispatch('refresh')
+    await dispatch('forceRefresh')
     commit('finish')
     return state.accessToken
   },
   create ({ state, commit, dispatch }, { refreshToken, accessToken }) {
     localStorage.setItem('refresh-token', refreshToken)
-    commit('insert', { refreshToken, accessToken })
+    commit('insert', { accessToken })
 
     setTimeout(() => {
       dispatch('refresh')
@@ -46,15 +52,27 @@ const actions = {
     commit('remove')
     return true
   },
-  refresh ({ state, commit, dispatch }) {
+  async refresh ({ state, getters, dispatch }) {
+    const accessToken = state.accessToken
+    const accessTokenExpiry = getters.accessTokenExpiresAt
+    const currentTime = Date.now() / 1000
+
+    if (!accessToken || accessTokenExpiry - 1800 < currentTime) {
+      await dispatch('forceRefresh')
+    }
+  },
+  async forceRefresh ({ state, commit, dispatch }) {
     const refreshToken = localStorage.getItem('refresh-token')
 
     if (refreshToken) {
-      return axios
+      await axios
         .post('/refresh', { refresh_token: refreshToken })
         .then((res) => {
-          localStorage.setItem('refresh-token', res.data.refresh_token)
-          commit('insert', { refreshToken: res.data.refresh_token, accessToken: res.data.access_token })
+          const refreshToken = res.data.refresh_token
+          const accessToken = res.data.access_token
+
+          localStorage.setItem('refresh-token', refreshToken)
+          commit('insert', { accessToken })
 
           setTimeout(() => {
             dispatch('refresh')
@@ -70,12 +88,10 @@ const actions = {
 }
 
 const mutations = {
-  insert (state, { refreshToken, accessToken }) {
-    state.refreshToken = refreshToken
+  insert (state, { accessToken }) {
     state.accessToken = accessToken
   },
   remove (state) {
-    state.refreshToken = null
     state.accessToken = null
   },
   finish (state) {

--- a/src/store/authentication/tokens.js
+++ b/src/store/authentication/tokens.js
@@ -52,6 +52,9 @@ const actions = {
     commit('remove')
     return true
   },
+  /**
+   * Refresh session if accessToken is near expiry or doesn't exist
+   */
   async refresh ({ state, getters, dispatch }) {
     const accessToken = state.accessToken
     const accessTokenExpiry = getters.accessTokenExpiresAt
@@ -61,6 +64,9 @@ const actions = {
       await dispatch('forceRefresh')
     }
   },
+  /**
+   * Force session refresh without checking accessToken
+   */
   async forceRefresh ({ state, commit, dispatch }) {
     const refreshToken = localStorage.getItem('refresh-token')
 

--- a/src/store/authentication/tokens.js
+++ b/src/store/authentication/tokens.js
@@ -43,7 +43,7 @@ const actions = {
 
     setTimeout(() => {
       dispatch('refresh')
-    }, 12600000) // 3.5 hours - TODO: Use exp value provided by accessToken
+    }, 120000) // 2 minutes
 
     return state.accessToken
   },
@@ -76,7 +76,7 @@ const actions = {
 
           setTimeout(() => {
             dispatch('refresh')
-          }, 12600000) // 3.5 hours - TODO: Use exp value provided by accessToken
+          }, 120000) // 2 minutes
 
           return state.accessToken
         })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -33,10 +33,20 @@ const actions = {
   }
 }
 
+const refreshSessionPlugin = (store) => {
+  store.subscribeAction((action, state) => {
+    if (!['authentication/tokens/refresh', 'authentication/tokens/forceRefresh'].includes(action.type)) {
+      console.log(action.type)
+      store.dispatch('authentication/tokens/refresh', null, { root: true })
+    }
+  })
+}
+
 const store = new Vuex.Store({
   state,
   getters,
   actions,
+  plugins: [refreshSessionPlugin],
   modules: {
     settings,
     authentication,


### PR DESCRIPTION
## Linked Issue(s)

- closes #9 

## Checklist

- [x] Check accessToken expiry prior to refresh action
- [x] Dispatch refresh from all actions requesting the API

Also adds...

`forceRefresh` action with old behaviour - no accessToken checking. Useful for init.

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn.js/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn.js/blob/master/CODE_OF_CONDUCT.md)
