### PR TITLE
add image uploads dialog to rich text editor image dialog

### DIFF
--- a/src/components/VRichTextEditor/RteImageDialog.vue
+++ b/src/components/VRichTextEditor/RteImageDialog.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-v-dialog(v-model="dialog" persistent max-width="290")
+v-dialog(v-model="dialog" max-width="290")
   template(v-slot:activator="{ on }")
     v-btn(icon v-on="on")
       v-icon mdi-image
@@ -11,6 +11,7 @@ v-dialog(v-model="dialog" persistent max-width="290")
           label="Image URL"
           v-model="image.src"
         )
+          image-upload-dialog(slot="append" v-model="image.src")
         v-text-field.ma-0.pa-0(
           label="Alt Text"
           v-model="image.alt"
@@ -25,8 +26,13 @@ v-dialog(v-model="dialog" persistent max-width="290")
 </template>
 
 <script>
+import ImageUploadDialog from './RteImageDialog/ImageUploadDialog'
+
 export default {
   props: ['command'],
+  components: {
+    ImageUploadDialog
+  },
   data () {
     return {
       dialog: false,

--- a/src/components/VRichTextEditor/RteImageDialog/ImageUploadDialog.vue
+++ b/src/components/VRichTextEditor/RteImageDialog/ImageUploadDialog.vue
@@ -1,0 +1,49 @@
+<template lang="pug">
+v-dialog(v-model="dialog" max-width="290")
+  template(v-slot:activator="{ on }")
+    v-btn(icon v-on="on")
+      v-icon mdi-paperclip
+  v-card
+    v-card-title(class="headline") Upload an image
+    v-card-text
+      upload-form(:upload="upload" :submit="create")
+</template>
+
+<script>
+import UploadForm from '../../../views/uploads/_form.vue'
+export default {
+  props: ['value'],
+  components: {
+    UploadForm
+  },
+  data () {
+    return {
+      dialog: false,
+      upload: {
+        file: null,
+        errors: []
+      }
+    }
+  },
+  computed: {
+    inputVal: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
+  },
+  methods: {
+    create: function () {
+      this.$store.dispatch('uploads/create', { workspaceId: this.$route.params.workspaceId, data: { upload: this.upload } }).then((res) => {
+        this.inputVal = res.file
+        this.dialog = false
+      }).catch((errors) => {
+        this.upload.errors = errors
+      })
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Linked Issue(s)

- closes #13 

## Description

### Feature

Adds image uploads capability to inline in Rich Text Editor.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/thombruce/helvellyn.js/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/thombruce/helvellyn.js/blob/master/CODE_OF_CONDUCT.md)
